### PR TITLE
Roofit task spec ctor fix

### DIFF
--- a/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
@@ -39,11 +39,11 @@ public:
 
   virtual Double_t combinedValue(RooAbsReal** gofArray, Int_t nVal) const ;
 
-  RooAbsReal& function() { return *_funcClone ; }
-  const RooAbsReal& function() const { return *_funcClone ; }
+  virtual RooAbsReal& function() { return *_funcClone ; }
+  virtual const RooAbsReal& function() const { return *_funcClone ; }
 
-  RooAbsData& data() ;
-  const RooAbsData& data() const ;
+  virtual RooAbsData& data() ;
+  virtual const RooAbsData& data() const ;
 
 
   virtual const char* cacheUniqueSuffix() const { return Form("_%lx", (ULong_t)_dataClone) ; }

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -68,6 +68,12 @@ public:
   virtual Double_t offset() const { return _offset ; }
   virtual Double_t offsetCarry() const { return _offsetCarry; }
 
+  virtual RooAbsReal& function() { return *_func ; }
+  virtual const RooAbsReal& function() const { return *_func ; }
+
+  virtual RooAbsData& data() { return *_data ; }
+  virtual const RooAbsData& data() const { return *_data ; }
+
 protected:
 
   virtual void printCompactTreeHook(std::ostream& os, const char* indent="") ;

--- a/roofit/roofitcore/inc/RooTaskSpec.h
+++ b/roofit/roofitcore/inc/RooTaskSpec.h
@@ -17,14 +17,7 @@
 #define ROO_TASK_SPEC
 
 #include "RooFit.h"
-#include <cstdlib>
 #include <list>
-#include <sstream>
-#include "RooMsgService.h"
-#include "RooNLLVar.h"
-#include "RooAbsTestStatistic.h"
-#include "RooAbsOptTestStatistic.h"
-#include "RooAddition.h"
 #include "RooAbsTestStatistic.h"
 
 class RooArgList;
@@ -32,7 +25,7 @@ class RooArgList;
 class RooTaskSpec {
  public:
   RooTaskSpec();
-  RooTaskSpec(RooAbsOptTestStatistic* nll);
+  RooTaskSpec(RooAbsTestStatistic* rats_nll);
   RooTaskSpec(RooAbsReal* nll);
   struct Task {
     Int_t id;
@@ -43,8 +36,8 @@ class RooTaskSpec {
   };
   std::list<Task> tasks;
  private:
-  void _initialise(RooAbsOptTestStatistic* rats);
-  Task _fill_task(const Int_t n, RooAbsOptTestStatistic* rats);
+  void _initialise(RooAbsTestStatistic* rats);
+  Task _fill_task(const Int_t n, RooAbsTestStatistic* rats);
   Int_t _fit_case;
   Int_t n_tasks = tasks.size();
 

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -815,33 +815,33 @@ Bool_t RooAbsOptTestStatistic::setDataSlave(RooAbsData& indata, Bool_t cloneData
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooAbsData& RooAbsOptTestStatistic::data() 
-{ 
+RooAbsData& RooAbsOptTestStatistic::data()
+{
   if (_sealed) {
     Bool_t notice = (sealNotice() && strlen(sealNotice())) ;
-    coutW(ObjectHandling) << "RooAbsOptTestStatistic::data(" << GetName() 
-			  << ") WARNING: object sealed by creator - access to data is not permitted: " 
+    coutW(ObjectHandling) << "RooAbsOptTestStatistic::data(" << GetName()
+			  << ") WARNING: object sealed by creator - access to data is not permitted: "
 			  << (notice?sealNotice():"<no user notice>") << endl ;
     static RooDataSet dummy ("dummy","dummy",RooArgSet()) ;
     return dummy ;
   }
-  return *_dataClone ; 
+  return *_dataClone ;
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const RooAbsData& RooAbsOptTestStatistic::data() const 
-{ 
+const RooAbsData& RooAbsOptTestStatistic::data() const
+{
   if (_sealed) {
     Bool_t notice = (sealNotice() && strlen(sealNotice())) ;
-    coutW(ObjectHandling) << "RooAbsOptTestStatistic::data(" << GetName() 
-			  << ") WARNING: object sealed by creator - access to data is not permitted: " 
+    coutW(ObjectHandling) << "RooAbsOptTestStatistic::data(" << GetName()
+			  << ") WARNING: object sealed by creator - access to data is not permitted: "
 			  << (notice?sealNotice():"<no user notice>") << endl ;
     static RooDataSet dummy ("dummy","dummy",RooArgSet()) ;
     return dummy ;
   }
-  return *_dataClone ; 
+  return *_dataClone ;
 }
 
 

--- a/roofit/roofitcore/src/RooTaskSpec.cxx
+++ b/roofit/roofitcore/src/RooTaskSpec.cxx
@@ -37,18 +37,12 @@ ToDo: Simple use demonstration.
 **/
 
 
-#include "Riostream.h"
-#include "RooFit.h"
-#include <cstdlib>
-#include <sstream>
-#include "RooMsgService.h"
-#include "RooNLLVar.h"
-#include "RooAbsTestStatistic.h"
-#include "RooAbsOptTestStatistic.h"
-#include "RooAddition.h"
-#include "RooAbsTestStatistic.h"
 #include "RooTaskSpec.h"
-#include "RooAbsData.h"
+// #include "Riostream.h"
+// #include "RooFit.h"
+// #include <sstream>
+#include "RooAbsTestStatistic.h"
+#include "RooAddition.h"
 
 using namespace std;
 using namespace RooFit;
@@ -56,17 +50,11 @@ using namespace RooFit;
 //ClassImp(RooTaskSpec);
 RooTaskSpec::RooTaskSpec(){};
 
-RooTaskSpec::RooTaskSpec(RooAbsOptTestStatistic* nll){
-  cout <<"starting case1"<<endl;
-  RooAbsOptTestStatistic* rats = dynamic_cast<RooAbsOptTestStatistic*>(nll) ;
-  if (rats) {
-    cout << " NLL is a RooAbsOptTestStatistic (Case 1)" << endl ;
-    rats->Print();
-    _fit_case = 1;
-    _initialise(rats);
-  } else {
-    _fit_case = 0;
-  }
+RooTaskSpec::RooTaskSpec(RooAbsTestStatistic* rats_nll){
+  cout << " NLL is a RooAbsTestStatistic (Case 1)" << endl ;
+  rats_nll->Print();
+  _fit_case = 1;
+  _initialise(rats_nll);
 }
 
 RooTaskSpec::RooTaskSpec(RooAbsReal* nll){
@@ -76,14 +64,14 @@ RooTaskSpec::RooTaskSpec(RooAbsReal* nll){
   ra->Print();
   cout <<"printed"<<endl;
   if (ra) {
-    RooAbsOptTestStatistic* rats = dynamic_cast<RooAbsOptTestStatistic*>(ra->list().at(0)) ;
+    RooAbsTestStatistic* rats = dynamic_cast<RooAbsTestStatistic*>(ra->list().at(0)) ;
     if (!rats) {
-      cout << "ERROR: NLL is a RooAddition, but first element of addition is not a RooAbsOptTestStatistic!" << endl ;
+      cout << "ERROR: NLL is a RooAddition, but first element of addition is not a RooAbsTestStatistic!" << endl ;
       _fit_case = 0;
       cout << "It is a "<<ra->list().at(0)<<endl;
     } else {
       _fit_case = 1;
-      cout << "NLL is a RooAddition (Case 2), first element is a RooAbsOptTestStatistic" << endl ;
+      cout << "NLL is a RooAddition (Case 2), first element is a RooAbsTestStatistic" << endl ;
       _initialise(rats);
     }
   }
@@ -93,7 +81,7 @@ RooTaskSpec::RooTaskSpec(RooAbsReal* nll){
 }
 
 
-void RooTaskSpec::_initialise (RooAbsOptTestStatistic* rats){
+void RooTaskSpec::_initialise (RooAbsTestStatistic* rats){
   // Check if nll is a AbsTestStatistic
   if (rats->numSimultaneous()==0){
     //    _set.add(_fill_task(0, rats));
@@ -102,13 +90,13 @@ void RooTaskSpec::_initialise (RooAbsOptTestStatistic* rats){
     for (Int_t i=0 ; i < rats->numSimultaneous() ; i++) {
       cout << "SimComponent #" << i << " = " ; 
       rats->simComponents()[i]->Print() ;
-      RooAbsOptTestStatistic* comp = (RooAbsOptTestStatistic*) rats->simComponents()[i] ;
+      RooAbsTestStatistic* comp = (RooAbsTestStatistic*) rats->simComponents()[i] ;
       tasks.push_back(_fill_task(i, comp));
     }
   }
 }
 
-RooTaskSpec::Task RooTaskSpec::_fill_task(Int_t n, RooAbsOptTestStatistic* rats){
+RooTaskSpec::Task RooTaskSpec::_fill_task(Int_t n, RooAbsTestStatistic* rats){
   Bool_t b = rats->function().getAttribute("BinnedLikelihood") ;
   Task t;
   t.id = n;

--- a/roofit/roofitcore/src/RooTaskSpec.cxx
+++ b/roofit/roofitcore/src/RooTaskSpec.cxx
@@ -43,6 +43,7 @@ ToDo: Simple use demonstration.
 // #include <sstream>
 #include "RooAbsTestStatistic.h"
 #include "RooAddition.h"
+#include "RooAbsData.h"
 
 using namespace std;
 using namespace RooFit;


### PR DESCRIPTION
Changed the argument from RAOTS to RATS in one of the constructors. It is called with a RATS from the MPFE ctor via RATS::initialize(), but never called with a RAOTS as far as I could see.